### PR TITLE
chore: disable component inclusion in release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
This is standard, and what is required for louhi to pick up the release PR.

