### PR TITLE
fix: avoid data race when resolving multiple auth tokens in Tool.execute

### DIFF
--- a/src/main/java/com/google/cloud/mcp/Tool.java
+++ b/src/main/java/com/google/cloud/mcp/Tool.java
@@ -16,11 +16,14 @@
 
 package com.google.cloud.mcp;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Represents a loaded tool ready to be invoked. Handles parameter binding, authentication token
@@ -122,35 +125,38 @@ public class Tool {
       }
     }
 
-    // 2. Resolve Auth Tokens
-    return CompletableFuture.allOf(
-            authGetters.entrySet().stream()
-                .map(
-                    entry -> {
-                      String serviceName = entry.getKey();
-                      return entry
-                          .getValue()
-                          .getToken()
-                          .thenAccept(
-                              token -> {
-                                // A. Check if mapped to a Parameter (Authenticated Parameters)
-                                String paramName = findParameterForService(serviceName);
-                                if (paramName != null) {
-                                  finalArgs.put(paramName, token);
-                                }
+    // 2. Resolve Auth Tokens.
+    // The tokens are fetched concurrently, but their results are applied to the
+    // (non-thread-safe) finalArgs / extraHeaders maps on a single thread, after all
+    // futures have completed. Mutating those HashMaps from each getter's completion
+    // thread (as the previous implementation did) is a data race that can drop a
+    // credential header or an authenticated argument from the outgoing request.
+    List<Map.Entry<String, AuthTokenGetter>> getters = new ArrayList<>(authGetters.entrySet());
+    List<CompletableFuture<String>> tokenFutures =
+        getters.stream().map(entry -> entry.getValue().getToken()).collect(Collectors.toList());
 
-                                // B. Always add to Headers to support Authorized Invocation
-                                // 1. Standard OIDC Header (Cloud Run)
-                                extraHeaders.put("Authorization", "Bearer " + token);
-
-                                // 2. SDK Convention Header (Framework Compatibility)
-                                extraHeaders.put(serviceName + "_token", token);
-                              });
-                    })
-                .toArray(CompletableFuture[]::new))
+    return CompletableFuture.allOf(tokenFutures.toArray(new CompletableFuture[0]))
         .thenCompose(
             v -> {
               try {
+                for (int i = 0; i < getters.size(); i++) {
+                  String serviceName = getters.get(i).getKey();
+                  String token = tokenFutures.get(i).join();
+
+                  // A. Check if mapped to a Parameter (Authenticated Parameters)
+                  String paramName = findParameterForService(serviceName);
+                  if (paramName != null) {
+                    finalArgs.put(paramName, token);
+                  }
+
+                  // B. Always add to Headers to support Authorized Invocation
+                  // 1. Standard OIDC Header (Cloud Run)
+                  extraHeaders.put("Authorization", "Bearer " + token);
+
+                  // 2. SDK Convention Header (Framework Compatibility)
+                  extraHeaders.put(serviceName + "_token", token);
+                }
+
                 // 3. Validation & Cleanup
                 validateAndSanitizeArgs(finalArgs);
                 return client.invokeTool(name, finalArgs, extraHeaders);

--- a/src/test/java/com/google/cloud/mcp/ToolTest.java
+++ b/src/test/java/com/google/cloud/mcp/ToolTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ToolTest {
+
+  private ExecutorService pool;
+
+  @BeforeEach
+  void setUp() {
+    pool = Executors.newFixedThreadPool(8);
+  }
+
+  @AfterEach
+  void tearDown() {
+    pool.shutdownNow();
+  }
+
+  /**
+   * Regression test: when several authenticated services resolve their tokens concurrently, {@link
+   * Tool#execute(Map)} must not drop any credential header or authenticated argument from the
+   * outgoing request. The previous implementation mutated the non-thread-safe finalArgs /
+   * extraHeaders HashMaps from each getter's completion thread, which could lose writes.
+   */
+  @Test
+  void execute_withManyConcurrentAuthGetters_doesNotDropCredentials() {
+    int services = Integer.getInteger("toolTest.services", 24);
+    int iterations = Integer.getInteger("toolTest.iters", 2500);
+
+    List<ToolDefinition.Parameter> params = new ArrayList<>();
+    for (int i = 0; i < services; i++) {
+      params.add(new ToolDefinition.Parameter("p" + i, "string", false, "", List.of("svc" + i)));
+    }
+    ToolDefinition def = new ToolDefinition("race-tool", params, new ArrayList<>());
+
+    List<Map<String, Object>> capturedArgs = new ArrayList<>();
+    List<Map<String, String>> capturedHeaders = new ArrayList<>();
+
+    @SuppressWarnings("unchecked")
+    McpToolboxClient client = mock(McpToolboxClient.class);
+    when(client.invokeTool(anyString(), anyMap(), anyMap()))
+        .thenAnswer(
+            inv -> {
+              capturedArgs.add(new HashMap<>(inv.getArgument(1)));
+              capturedHeaders.add(new HashMap<>(inv.getArgument(2)));
+              return CompletableFuture.completedFuture(
+                  new ToolResult(List.of(new ToolResult.Content("text", "ok")), false));
+            });
+
+    Tool tool = new Tool("race-tool", def, client);
+    for (int i = 0; i < services; i++) {
+      final String token = "tok-" + i;
+      tool.addAuthTokenGetter(
+          "svc" + i,
+          () ->
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    int spins = ThreadLocalRandom.current().nextInt(50);
+                    for (int s = 0; s < spins; s++) {
+                      Thread.onSpinWait();
+                    }
+                    return token;
+                  },
+                  pool));
+    }
+
+    for (int iter = 0; iter < iterations; iter++) {
+      tool.execute(new HashMap<>()).join();
+    }
+
+    assertEquals(iterations, capturedHeaders.size(), "every invocation should reach the client");
+    for (int iter = 0; iter < iterations; iter++) {
+      Map<String, String> headers = capturedHeaders.get(iter);
+      Map<String, Object> args = capturedArgs.get(iter);
+      for (int i = 0; i < services; i++) {
+        assertEquals(
+            "tok-" + i,
+            headers.get("svc" + i + "_token"),
+            "missing/garbled svc" + i + "_token header on iteration " + iter);
+        assertEquals(
+            "tok-" + i, args.get("p" + i), "missing/garbled p" + i + " arg on iteration " + iter);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
Fixes a data race in `Tool.execute(Map)` when a tool has more than one
authentication source.

## Background
`execute()` resolves all registered `AuthTokenGetter`s concurrently and, inside
each token's `thenAccept(...)` completion callback, writes to the same two
**non-thread-safe** `java.util.HashMap` instances that assemble the outgoing
request:

```java
Map<String, Object> finalArgs   = new HashMap<>(args);
Map<String, String> extraHeaders = new HashMap<>();
...
.thenAccept(token -> {
    finalArgs.put(paramName, token);                 // concurrent put
    extraHeaders.put("Authorization", "Bearer " + token);
    extraHeaders.put(serviceName + "_token", token); // concurrent put
});
```

When two or more getters complete on different threads, these concurrent
`HashMap.put` calls can lose writes or corrupt the table (classic lost-update on
resize). The result is an outgoing `tools/call` that is **missing a per-service
credential header (`<service>_token`) or an authenticated argument** — i.e. the
request goes out in a credential state the developer did not intend.

## Fix
Fetch the tokens concurrently as before, then apply their results to
`finalArgs` / `extraHeaders` on a **single thread** after
`CompletableFuture.allOf(...)` completes. No concurrent mutation, no new
dependency, behavior preserved (bound-parameter precedence, null filtering,
header/arg population). `Authorization` "last writer" is now deterministic
(iteration order) instead of racy.

## Test
Adds `ToolTest.execute_withManyConcurrentAuthGetters_doesNotDropCredentials`: it
registers many async auth getters and asserts every invocation carries all
`<service>_token` headers and all authenticated arguments. It **fails on the
previous implementation** (a credential is dropped) and **passes** with this fix.

## Notes
- No new dependencies (uses existing `CompletableFuture`, JDK collections).
- Async-first architecture preserved.
- `mvn com.spotify.fmt:fmt-maven-plugin:format` clean.