### PR TITLE
refactor: resolve multiple auth tokens concurrently and safely in Tool.execute

### DIFF
--- a/src/main/java/com/google/cloud/mcp/AuthResolver.java
+++ b/src/main/java/com/google/cloud/mcp/AuthResolver.java
@@ -44,7 +44,10 @@ public final class AuthResolver {
             v -> {
               Map<String, String> resolved = new HashMap<>();
               for (int i = 0; i < entries.size(); i++) {
-                resolved.put(entries.get(i).getKey(), futures.get(i).join());
+                String token = futures.get(i).join();
+                if (token != null) {
+                  resolved.put(entries.get(i).getKey(), token);
+                }
               }
               return new ResolvedAuth(resolved);
             });

--- a/src/main/java/com/google/cloud/mcp/AuthResolver.java
+++ b/src/main/java/com/google/cloud/mcp/AuthResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.mcp;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handles concurrent resolution of token getters into a {@link ResolvedAuth} instance. */
+public final class AuthResolver {
+  private AuthResolver() {}
+
+  /**
+   * Concurrently resolves all registered token getters.
+   *
+   * @param getters The map of service name to token getter.
+   * @return A CompletableFuture containing the resolved auth object.
+   */
+  public static CompletableFuture<ResolvedAuth> resolve(Map<String, AuthTokenGetter> getters) {
+    if (getters.isEmpty()) {
+      return CompletableFuture.completedFuture(new ResolvedAuth(Map.of()));
+    }
+
+    var entries = List.copyOf(getters.entrySet());
+    var futures = entries.stream().map(entry -> entry.getValue().getToken()).toList();
+
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        .thenApply(
+            v -> {
+              Map<String, String> resolved = new HashMap<>();
+              for (int i = 0; i < entries.size(); i++) {
+                resolved.put(entries.get(i).getKey(), futures.get(i).join());
+              }
+              return new ResolvedAuth(resolved);
+            });
+  }
+}

--- a/src/main/java/com/google/cloud/mcp/ResolvedAuth.java
+++ b/src/main/java/com/google/cloud/mcp/ResolvedAuth.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.mcp;
+
+import java.util.Map;
+
+/** Represents a resolved set of authentication credentials for a tool execution. */
+public final class ResolvedAuth {
+  private final Map<String, String> tokens;
+
+  public ResolvedAuth(Map<String, String> tokens) {
+    this.tokens = Map.copyOf(tokens);
+  }
+
+  /**
+   * Applies the resolved credentials to the outgoing request parameters and headers.
+   *
+   * @param finalArgs The map of arguments for the tool execution.
+   * @param extraHeaders The map of extra headers for the tool execution.
+   * @param definition The tool definition to inspect for parameter auth mappings.
+   */
+  public void applyTo(
+      Map<String, Object> finalArgs, Map<String, String> extraHeaders, ToolDefinition definition) {
+
+    for (Map.Entry<String, String> entry : tokens.entrySet()) {
+      String serviceName = entry.getKey();
+      String token = entry.getValue();
+      if (token == null || token.isEmpty()) {
+        continue;
+      }
+
+      // A. Parameter mapping
+      String paramName = findParameterForService(definition, serviceName);
+      if (paramName != null) {
+        finalArgs.put(paramName, token);
+      }
+
+      // B. Header mapping
+      // Normalize to prevent double-prefixing if the provider already prefixed the token
+      String authorizationHeaderValue = token.startsWith("Bearer ") ? token : "Bearer " + token;
+      extraHeaders.put("Authorization", authorizationHeaderValue);
+      extraHeaders.put(serviceName + "_token", token);
+    }
+  }
+
+  private static String findParameterForService(ToolDefinition definition, String serviceName) {
+    if (definition.parameters() == null) return null;
+    for (ToolDefinition.Parameter param : definition.parameters()) {
+      if (param.authSources() != null && param.authSources().contains(serviceName)) {
+        return param.name();
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/google/cloud/mcp/ResolvedAuth.java
+++ b/src/main/java/com/google/cloud/mcp/ResolvedAuth.java
@@ -23,7 +23,15 @@ public final class ResolvedAuth {
   private final Map<String, String> tokens;
 
   public ResolvedAuth(Map<String, String> tokens) {
-    this.tokens = Map.copyOf(tokens);
+    Map<String, String> copy = new java.util.HashMap<>();
+    if (tokens != null) {
+      for (Map.Entry<String, String> entry : tokens.entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          copy.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+    this.tokens = Map.copyOf(copy);
   }
 
   /**
@@ -51,7 +59,8 @@ public final class ResolvedAuth {
 
       // B. Header mapping
       // Normalize to prevent double-prefixing if the provider already prefixed the token
-      String authorizationHeaderValue = token.startsWith("Bearer ") ? token : "Bearer " + token;
+      String authorizationHeaderValue =
+          token.regionMatches(true, 0, "Bearer ", 0, 7) ? token : "Bearer " + token;
       extraHeaders.put("Authorization", authorizationHeaderValue);
       extraHeaders.put(serviceName + "_token", token);
     }

--- a/src/main/java/com/google/cloud/mcp/Tool.java
+++ b/src/main/java/com/google/cloud/mcp/Tool.java
@@ -122,35 +122,14 @@ public class Tool {
       }
     }
 
-    // 2. Resolve Auth Tokens
-    return CompletableFuture.allOf(
-            authGetters.entrySet().stream()
-                .map(
-                    entry -> {
-                      String serviceName = entry.getKey();
-                      return entry
-                          .getValue()
-                          .getToken()
-                          .thenAccept(
-                              token -> {
-                                // A. Check if mapped to a Parameter (Authenticated Parameters)
-                                String paramName = findParameterForService(serviceName);
-                                if (paramName != null) {
-                                  finalArgs.put(paramName, token);
-                                }
-
-                                // B. Always add to Headers to support Authorized Invocation
-                                // 1. Standard OIDC Header (Cloud Run)
-                                extraHeaders.put("Authorization", "Bearer " + token);
-
-                                // 2. SDK Convention Header (Framework Compatibility)
-                                extraHeaders.put(serviceName + "_token", token);
-                              });
-                    })
-                .toArray(CompletableFuture[]::new))
+    // 2. Resolve Auth & Execute
+    return AuthResolver.resolve(authGetters)
         .thenCompose(
-            v -> {
+            resolvedAuth -> {
               try {
+                // Apply credential parameter bindings and extra headers
+                resolvedAuth.applyTo(finalArgs, extraHeaders, definition);
+
                 // 3. Validation & Cleanup
                 validateAndSanitizeArgs(finalArgs);
                 return client.invokeTool(name, finalArgs, extraHeaders);
@@ -158,16 +137,6 @@ public class Tool {
                 return CompletableFuture.failedFuture(e);
               }
             });
-  }
-
-  private String findParameterForService(String serviceName) {
-    if (definition.parameters() == null) return null;
-    for (ToolDefinition.Parameter param : definition.parameters()) {
-      if (param.authSources() != null && param.authSources().contains(serviceName)) {
-        return param.name();
-      }
-    }
-    return null;
   }
 
   /** Validates arguments against the tool definition and removes null values. */

--- a/src/test/java/com/google/cloud/mcp/ToolTest.java
+++ b/src/test/java/com/google/cloud/mcp/ToolTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ToolTest {
+
+  private ExecutorService pool;
+
+  @BeforeEach
+  void setUp() {
+    pool = Executors.newFixedThreadPool(8);
+  }
+
+  @AfterEach
+  void tearDown() {
+    pool.shutdownNow();
+  }
+
+  /**
+   * Regression test: when several authenticated services resolve their tokens concurrently, {@link
+   * Tool#execute(Map)} must not drop any credential header or authenticated argument from the
+   * outgoing request. The previous implementation mutated the non-thread-safe finalArgs /
+   * extraHeaders HashMaps from each getter's completion thread, which could lose writes.
+   */
+  @Test
+  void execute_withManyConcurrentAuthGetters_doesNotDropCredentials() {
+    int services = Integer.getInteger("toolTest.services", 24);
+    int iterations = Integer.getInteger("toolTest.iters", 2500);
+
+    List<ToolDefinition.Parameter> params = new ArrayList<>();
+    for (int i = 0; i < services; i++) {
+      params.add(new ToolDefinition.Parameter("p" + i, "string", false, "", List.of("svc" + i)));
+    }
+    ToolDefinition def = new ToolDefinition("race-tool", params, new ArrayList<>());
+
+    List<Map<String, Object>> capturedArgs = new ArrayList<>();
+    List<Map<String, String>> capturedHeaders = new ArrayList<>();
+
+    McpToolboxClient client = mock(McpToolboxClient.class);
+    when(client.invokeTool(anyString(), anyMap(), anyMap()))
+        .thenAnswer(
+            inv -> {
+              capturedArgs.add(new HashMap<>(inv.getArgument(1)));
+              capturedHeaders.add(new HashMap<>(inv.getArgument(2)));
+              return CompletableFuture.completedFuture(
+                  new ToolResult(List.of(new ToolResult.Content("text", "ok")), false));
+            });
+
+    Tool tool = new Tool("race-tool", def, client);
+    for (int i = 0; i < services; i++) {
+      final String token = "tok-" + i;
+      tool.addAuthTokenGetter(
+          "svc" + i,
+          () ->
+              CompletableFuture.supplyAsync(
+                  () -> {
+                    int spins = ThreadLocalRandom.current().nextInt(50);
+                    for (int s = 0; s < spins; s++) {
+                      Thread.onSpinWait();
+                    }
+                    return token;
+                  },
+                  pool));
+    }
+
+    for (int iter = 0; iter < iterations; iter++) {
+      tool.execute(new HashMap<>()).join();
+    }
+
+    assertEquals(iterations, capturedHeaders.size(), "every invocation should reach the client");
+    for (int iter = 0; iter < iterations; iter++) {
+      Map<String, String> headers = capturedHeaders.get(iter);
+      Map<String, Object> args = capturedArgs.get(iter);
+      for (int i = 0; i < services; i++) {
+        assertEquals(
+            "tok-" + i,
+            headers.get("svc" + i + "_token"),
+            "missing/garbled svc" + i + "_token header on iteration " + iter);
+        assertEquals(
+            "tok-" + i, args.get("p" + i), "missing/garbled p" + i + " arg on iteration " + iter);
+      }
+    }
+  }
+
+  @Test
+  void resolvedAuth_appliesTokensWithCorrectBearerNormalization() {
+    ToolDefinition def = new ToolDefinition("test-tool", List.of(), List.of());
+    Map<String, String> tokens =
+        Map.of(
+            "svc-raw", "rawToken123",
+            "svc-prefixed", "Bearer alreadyPrefixed456");
+
+    ResolvedAuth resolvedAuth = new ResolvedAuth(tokens);
+    Map<String, Object> finalArgs = new HashMap<>();
+    Map<String, String> extraHeaders = new HashMap<>();
+
+    resolvedAuth.applyTo(finalArgs, extraHeaders, def);
+
+    // Verify token values map to sdk custom headers
+    assertEquals("rawToken123", extraHeaders.get("svc-raw_token"));
+    assertEquals("Bearer alreadyPrefixed456", extraHeaders.get("svc-prefixed_token"));
+
+    // Verify standard OIDC authorization header matches and doesn't double prefix
+    // (Note: since map is hashmap, it will end with one of them depending on iteration order)
+    String authHeader = extraHeaders.get("Authorization");
+    assertTrue(
+        authHeader.equals("Bearer rawToken123") || authHeader.equals("Bearer alreadyPrefixed456"));
+  }
+}

--- a/src/test/java/com/google/cloud/mcp/ToolTest.java
+++ b/src/test/java/com/google/cloud/mcp/ToolTest.java
@@ -121,7 +121,8 @@ class ToolTest {
     Map<String, String> tokens =
         Map.of(
             "svc-raw", "rawToken123",
-            "svc-prefixed", "Bearer alreadyPrefixed456");
+            "svc-prefixed", "Bearer alreadyPrefixed456",
+            "svc-lowercase-prefixed", "bearer alreadyPrefixed789");
 
     ResolvedAuth resolvedAuth = new ResolvedAuth(tokens);
     Map<String, Object> finalArgs = new HashMap<>();
@@ -132,11 +133,34 @@ class ToolTest {
     // Verify token values map to sdk custom headers
     assertEquals("rawToken123", extraHeaders.get("svc-raw_token"));
     assertEquals("Bearer alreadyPrefixed456", extraHeaders.get("svc-prefixed_token"));
+    assertEquals("bearer alreadyPrefixed789", extraHeaders.get("svc-lowercase-prefixed_token"));
 
     // Verify standard OIDC authorization header matches and doesn't double prefix
-    // (Note: since map is hashmap, it will end with one of them depending on iteration order)
     String authHeader = extraHeaders.get("Authorization");
     assertTrue(
-        authHeader.equals("Bearer rawToken123") || authHeader.equals("Bearer alreadyPrefixed456"));
+        authHeader.equals("Bearer rawToken123")
+            || authHeader.equals("Bearer alreadyPrefixed456")
+            || authHeader.equals("bearer alreadyPrefixed789"));
+  }
+
+  @Test
+  void resolvedAuth_withNullAndEmptyTokens_ignoresThemSafely() {
+    ToolDefinition def = new ToolDefinition("test-tool", List.of(), List.of());
+    Map<String, String> tokens = new HashMap<>();
+    tokens.put("svc-null", null);
+    tokens.put("svc-empty", "");
+    tokens.put("svc-valid", "validToken");
+
+    ResolvedAuth resolvedAuth = new ResolvedAuth(tokens);
+    Map<String, Object> finalArgs = new HashMap<>();
+    Map<String, String> extraHeaders = new HashMap<>();
+
+    resolvedAuth.applyTo(finalArgs, extraHeaders, def);
+
+    // Only the valid token should be mapped
+    assertEquals("Bearer validToken", extraHeaders.get("Authorization"));
+    assertEquals("validToken", extraHeaders.get("svc-valid_token"));
+    assertTrue(!extraHeaders.containsKey("svc-null_token"));
+    assertTrue(!extraHeaders.containsKey("svc-empty_token"));
   }
 }


### PR DESCRIPTION
## Summary
Refactors token resolution in `Tool.execute(Map)` to resolve all registered `AuthTokenGetter`s concurrently but apply their results to the non-thread-safe outgoing request HashMaps (`finalArgs` and `extraHeaders`) sequentially. This prevents data race conditions and lost updates that occurred when multiple getters resolved concurrently. Also introduces clean class abstractions (`AuthResolver` and `ResolvedAuth`) and fixes potential double-prefixing of the `"Bearer "` authorization token.

## Expectation & Implementation
- **Problem**: When a tool has multiple credential sources, their `AuthTokenGetter.getToken()` callbacks resolve concurrently. In the original implementation, each getter modified the non-thread-safe `HashMap` instances (`finalArgs`, `extraHeaders`) from its completion thread, leading to concurrent mutations, lost updates, and missing credential headers.
- **Abstractions**:
  - `AuthResolver`: A runner class that asynchronously resolves all tokens concurrently and groups them into a `ResolvedAuth` object.
  - `ResolvedAuth`: A value container holding resolved credentials. It encapsulates the mapping rules of service tokens to method arguments and OIDC header formats.
- **Double-Prefix Normalization**: Checked if the token returned by a provider already contains a `"Bearer "` prefix (which is the default for Google OIDC token getters) and normalizes it to prevent double-prefixing (`Bearer Bearer ...`).

## Test cases
- **Unit and Regression Testing**: Added `ToolTest.java` containing:
  - `execute_withManyConcurrentAuthGetters_doesNotDropCredentials`: Regresses the concurrency race condition. Registers 24 concurrent getters with random spin-waits and runs 2,500 sequential invocations to verify that no credential headers or arguments are dropped. Fails on the buggy code and passes with this implementation.
  - `resolvedAuth_appliesTokensWithCorrectBearerNormalization`: Validates that OIDC authorization headers do not get double-prefixed if the token returned is already prefixed with `"Bearer "`.
- **How to execute locally**:
  `mvn test -Dtest="*Test,!*E2ETest" -Dnet.bytebuddy.experimental=true`

## Acceptance criteria
- Full build completes successfully with no checkstyle or compiler errors.
- Unit and regression tests pass consistently.
- No public APIs or user-facing signatures are broken.

## Breaking changes
None.
