### PR TITLE
chore: configure release-please for major 1.0.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": false,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "changelog-sections": [


### PR DESCRIPTION
## Summary
Configures Release Please for GA releases by setting `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` to `false` in `release-please-config.json`, enabling major version bumps for 1.0.0.

## Expectation & Implementation
- Disables pre-major versioning mode in Release Please.
- Allows Release Please to treat breaking changes as major version bumps, triggering the transition from `0.2.0` to `1.0.0` in the automated release PR.
- Ensures future post-1.0 breaking changes properly bump the major version.

Release-As: 1.0.0

## Test cases
- CI workflows (Lint, Compile, Security checks) validate configuration correctness.

## Acceptance criteria
- [x] Conforms to Conventional Commits standard.
- [x] Includes `Release-As: 1.0.0` footer for Release Please.
- [x] Pre-major configuration flags set to `false`.
- [x] All presubmit CI checks pass cleanly.

## Breaking changes
None directly introduced by this PR.